### PR TITLE
Strip comments from .jshintrc file

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,19 @@ install
 
 Use from BBEdit's Scripts menu by either installing or symlinking `bbjshint` to BBEdit's Scripts folder. This is `~/Library/Application Support/BBEdit/Scripts` or perhaps `~/Dropbox/Application Support/BBEdit/Scripts`. You can show this folder from BBEdit by going to the scripts menu and choosing "Open Scripts Folder".
 
-    npm install --global bbjshint
-    cd ~/Library/Application\ Support/BBEdit/Scripts
+    npm install --global bbjshint (or, sudo npm install --global bbjshint)
+    cd ~/"Library/Application Support/BBEdit/Scripts/"
     ln -s `which bbjshint`
+
+usage
+-----
+Custom `.jshintrc` files can be used. They should be placed in the same directory as the original file with javascript code.
+See: https://github.com/jshint/jshint/blob/master/examples/.jshintrc
 
 contributors
 ------------
 [Nate Silva](https://github.com/natesilva)
+[Daniel Caspi](https://github.com/dxdc)
 
 acknowledgements
 ----------------

--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ Use from BBEdit's Scripts menu by either installing or symlinking `bbjshint` to 
 
 usage
 -----
-Custom `.jshintrc` files can be used. They should be placed in the same directory as the original file with javascript code.
+Custom `.jshintrc` files can be used. They should be placed in the same directory as the original folder with javascript code.
 See: https://github.com/jshint/jshint/blob/master/examples/.jshintrc
 
 contributors
 ------------
-[Nate Silva](https://github.com/natesilva)
-[Daniel Caspi](https://github.com/dxdc)
+- [Nate Silva](https://github.com/natesilva)
+- [Daniel Caspi](https://github.com/dxdc)
 
 acknowledgements
 ----------------

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 #!/usr/local/bin/node
+
 /*jshint node:true */
 'use strict';
 
@@ -6,7 +7,7 @@ var fs = require('fs'),
     path = require('path'),
     lint = require('jshint').JSHINT,
     bbresults = require('bbresults'),
-
+    stripJsonComments = require('strip-json-comments'),
     title = 'JSHint results',
     pathname = process.env.BB_DOC_PATH;
 
@@ -18,7 +19,7 @@ function getOptions(dir) {
     }
 
     if (fs.existsSync(candidate = path.join(dir, '.jshintrc'))) {
-        opts = JSON.parse(fs.readFileSync(candidate));
+        opts = JSON.parse(stripJsonComments(fs.readFileSync(candidate)));
     }
 
     return opts || getOptions(path.join(dir, '..'));
@@ -26,10 +27,14 @@ function getOptions(dir) {
 
 function run(err, str) {
     if (err) {
-        bbresults.notify('error, reading ' + pathname, {title: title});
+        bbresults.notify('error, reading ' + pathname, {
+            title: title
+        });
 
-    } else if(lint(str, getOptions(path.dirname(pathname)))) {
-        bbresults.notify(pathname + ' is lint free', {title: title});
+    } else if (lint(str, getOptions(path.dirname(pathname)))) {
+        bbresults.notify(pathname + ' is lint free', {
+            title: title
+        });
 
     } else {
         bbresults.show(lint.errors, pathname, title);
@@ -38,7 +43,9 @@ function run(err, str) {
 
 if (require.main === module) {
     if (undefined === pathname) {
-        bbresults.notify('please save the document and try again', {title: title});
+        bbresults.notify('please save the document and try again', {
+            title: title
+        });
 
     } else {
         fs.readFile(pathname, 'utf-8', run);

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "bin": "index.js",
   "dependencies": {
     "bbresults": "~0.0.0",
-    "jshint": ">0.9.0"
+    "jshint": ">0.9.0",
+    "strip-json-comments": "~2.0.1"
   },
   "devDependencies": {
     "tape": "~2.3.2"


### PR DESCRIPTION
.jshintrc is populated with comments by defaults; these commits strip the comments from the .jshintrc file allowing it to be used as is.